### PR TITLE
Cludge to fix image width cropping

### DIFF
--- a/src/jseshtext.java
+++ b/src/jseshtext.java
@@ -27,7 +27,7 @@ public class jseshtext {
         
         // Override JSesh's max size parameter to something absurdly huge
         // so that images don't crop arbitrarily at 2000 pixels wide
-        // - christiancasey 04-03-2022
+        // - christiancasey 2022-03-04
         drawing.setMaxSize(500000,10000); 
         
         // Change the scale, choosing the cadrat height in pixels.

--- a/src/jseshtext.java
+++ b/src/jseshtext.java
@@ -24,6 +24,12 @@ public class jseshtext {
     public static BufferedImage buildImage(String mdcText) throws MDCSyntaxError {
         // Create the drawing system:                
         MDCDrawingFacade drawing = new MDCDrawingFacade();
+        
+        // Override JSesh's max size parameter to something absurdly huge
+        // so that images don't crop arbitrarily at 2000 pixels wide
+        // - christiancasey 04-03-2022
+        drawing.setMaxSize(500000,10000); 
+        
         // Change the scale, choosing the cadrat height in pixels.
         drawing.setCadratHeight(60);
         // Change a number of parameters 


### PR DESCRIPTION
This is not the most elegant solution, but it ensures that the output images won't be limited to 2000 pixels wide. They are now limited to 500k pixels wide, so don't write that many hieroglyphics in a single line I guess.